### PR TITLE
autocompletion for create EXTERNAL TABLE in psql

### DIFF
--- a/src/bin/psql/tab-complete.c
+++ b/src/bin/psql/tab-complete.c
@@ -1006,6 +1006,7 @@ static const pgsql_thing_t words_after_create[] = {
 	{"DOMAIN", NULL, NULL, &Query_for_list_of_domains},
 	{"EVENT TRIGGER", NULL, NULL, NULL},
 	{"EXTENSION", Query_for_list_of_extensions},
+	{"EXTERNAL TABLE", NULL, NULL, NULL},
 	{"FOREIGN DATA WRAPPER", NULL, NULL, NULL},
 	{"FOREIGN TABLE", NULL, NULL, NULL},
 	{"FUNCTION", NULL, NULL, Query_for_list_of_functions},


### PR DESCRIPTION
Extends the psql console utility. It's autocompletion capabilities with the "CREATE EXTERNAL TABLE" syntax. Now, when you type "CREATE EXT" and press Tab, both options will be offered: "CREATE EXTENSION" and "CREATE EXTERNAL TABLE".

